### PR TITLE
Revealing islands

### DIFF
--- a/script.js
+++ b/script.js
@@ -71,6 +71,28 @@ function handleClick(row, col, board) {
   board[row][col] = { ...cell, revealed: true };
   boardCell.classList.add("revealed");
 
+  // Reveal all adjacent blank cells and their adjacent cells
+  if (!cell.mine) {
+    for (let r = -1; r <= 1; r++) {
+      for (let c = -1; c <= 1; c++) {
+        const newRow = row + r;
+        const newCol = col + c;
+
+        if (
+          newRow >= 0 &&
+          newRow < BOARD_SIZE &&
+          newCol >= 0 &&
+          newCol < BOARD_SIZE &&
+          !board[newRow][newCol].mine &&
+          countAdjacentMines(newRow, newCol, board) === 0
+        ) 
+        {
+          handleClick(newRow, newCol, board);
+        }
+      }
+    }
+  }
+
   if (cell.mine) {
     boardCell.classList.add("mine");
     alert("Game over! You hit a mine.");

--- a/script.js
+++ b/script.js
@@ -73,21 +73,43 @@ function handleClick(row, col, board) {
 
   // Reveal all adjacent blank cells and their adjacent cells
   if (!cell.mine) {
-    for (let r = -1; r <= 1; r++) {
-      for (let c = -1; c <= 1; c++) {
-        const newRow = row + r;
-        const newCol = col + c;
+    if (countAdjacentMines(row, col, board) === 0) {
+      // Reveal all cells around this one
+      for (let r = -1; r <= 1; r++) {
+        for (let c = -1; c <= 1; c++) {
+          const newRow = row + r;
+          const newCol = col + c;
 
-        if (
-          newRow >= 0 &&
-          newRow < BOARD_SIZE &&
-          newCol >= 0 &&
-          newCol < BOARD_SIZE &&
-          !board[newRow][newCol].mine &&
-          countAdjacentMines(newRow, newCol, board) === 0
-        ) 
-        {
-          handleClick(newRow, newCol, board);
+          if (
+            newRow >= 0 &&
+            newRow < BOARD_SIZE &&
+            newCol >= 0 &&
+            newCol < BOARD_SIZE &&
+            !board[newRow][newCol].mine
+          ) {
+            handleClick(newRow, newCol, board);
+          }
+        }
+      }
+    }
+    else {
+      // Reveal all blank cells around this one
+      for (let r = -1; r <= 1; r++) {
+        for (let c = -1; c <= 1; c++) {
+          const newRow = row + r;
+          const newCol = col + c;
+
+          if (
+            newRow >= 0 &&
+            newRow < BOARD_SIZE &&
+            newCol >= 0 &&
+            newCol < BOARD_SIZE &&
+            !board[newRow][newCol].mine &&
+            countAdjacentMines(newRow, newCol, board) === 0
+          ) 
+          {
+            handleClick(newRow, newCol, board);
+          }
         }
       }
     }


### PR DESCRIPTION
Updated the code for clicks to reveal block islands rather than individual blocks. This means a click will reveal the block clicked, all interconnectedly adjacent blank blocks, and the blocks adjacent to these blank blocks.